### PR TITLE
fix: check color alpha when `hex.count` == 1, 6, 7, 8

### DIFF
--- a/ios/Classes/UIColor.swift
+++ b/ios/Classes/UIColor.swift
@@ -7,9 +7,7 @@ extension UIColor {
         switch hex.count {
         case 3: // RGB (12-bit)
             (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
-        case 6: // RGB (24-bit)
-            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
-        case 8: // ARGB (32-bit)
+        case 1, 6, 7, 8: // ARGB (32-bit)
             (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
         default:
             (a, r, g, b) = (255, 0, 0, 0)


### PR DESCRIPTION
# Motivation
I have specified a background color that includes an alpha channel. But I noticed that it does not work and always appears as a color with 0 transparency. Upon investigation, I discovered that the problem was in the alpha channel conversion section (UIColor.swift).

In dart,
```dart
print(Colors.white.value.toRadixString(16))
// ffffffff

print(Colors.white.withAlpha(0).value.toRadixString(16))
// ffffff

print(Colors.white.withAlpha(1).value.toRadixString(16))
// 1ffffff

print(Colors.white.withOpacity(0).value.toRadixString(16))
// ffffff

print(Colors.white.withOpacity(0.01).value.toRadixString(16))
// 3ffffff

print(Colors.transparent.value.toRadixString(16))
// 0
```

In `UIColor.swift`,
Cases 1 and 7 will always show black because they are treated as defaults.

Therefore, the alpha channel is now also checked for cases 1, 6, and 7.

If you have any concerns, I would appreciate your comments.